### PR TITLE
[CI]: Fix fork-PR checkout blocked by security guard, keep auto-approve/reject

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,40 @@
+name: PR Review
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - name: Download PR number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - uses: mate-academy/auto-approve-action@v2
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        with:
+          github-token: ${{ github.token }}
+          pull-request-number: ${{ steps.pr.outputs.number }}
+
+      - uses: mate-academy/auto-reject-action@v2
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        with:
+          github-token: ${{ github.token }}
+          pull-request-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:
@@ -9,9 +11,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Set Up Python 3.10
         uses: actions/setup-python@v2
@@ -28,11 +27,14 @@ jobs:
       - name: Run tests
         timeout-minutes: 5
         run: python manage.py test
-      - uses: mate-academy/auto-approve-action@v2
-        if: ${{ github.event.pull_request && success() }}
+
+      - name: Save PR number
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR number
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ github.token }}
-      - uses: mate-academy/auto-reject-action@v2
-        if: ${{ github.event.pull_request && failure() }}
-        with:
-          github-token: ${{ github.token }}
+          name: pr-number
+          path: pr-number.txt


### PR DESCRIPTION
## Summary

GitHub hardened `actions/checkout` to refuse checking out fork PR code from a `pull_request_target` workflow (the "pwn request" guard), so every student fork PR failed at checkout. This splits the workflow so untrusted student code never runs with a write-scoped token, while preserving the auto-approve / auto-reject verdict:

- `test.yml` now triggers on `pull_request` (read-only token) and runs the existing checks against the student's code via the default checkout; it uploads the PR number as an artifact.
- `pr-review.yml` triggers on `workflow_run` (trusted context, write token) and posts approve (on success) or request-changes (on failure).

Note: `pr-review.yml` only arms once it is on the default branch.